### PR TITLE
Implement issue #6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage/
 dist/
 docs/
 jest-screenshot-report/
+/.idea

--- a/README.md
+++ b/README.md
@@ -143,6 +143,29 @@ describe("My fancy image", () => {
 });
 ```
 
+It is possible to import ```toMatchImageSnapshot()``` for custom assertions.
+As it requires configuration as second argument, ```config()``` function 
+(_which is responsible for reading configuration from  jest-screenshot.json/package.json_) is also exposed.
+
+```typescript
+import {config, toMatchImageSnapshot} from 'jest-screenshot';
+
+expect.extend({
+  customMatcher(received, name) {
+    const image = customGetImage(received); // i.e. via puppeteer, html2canvas etc
+    const configuration = config(); // get existing config
+    if(process.env.LOOSE_SCREENSHOTS_MATCH) {
+        // loose mismatch threshold for specific environment setting
+        configuration.pixelThresholdRelative = configuration.pixelThresholdRelative + 0.1
+    }
+    return toMatchImageSnapshot.call(this, image, configuration, {
+        // build custom path for screenshot
+        path: `/custom_file_path/${configuration.snapshotsDir}/custom_file_prefix_${name}.png`
+    });
+  }
+});
+```
+
 ## Benchmark
 
 This library is around 10x faster than [jest-image-snapshot](https://github.com/americanexpress/jest-image-snapshot).

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,4 +10,4 @@ declare global {
 
 export { setupJestScreenshot } from "./jest-screenshot";
 export { toMatchImageSnapshot } from "./to-match-image-snapshot";
-export { JestScreenshotConfiguration } from "./config";
+export { JestScreenshotConfiguration, config } from "./config";


### PR DESCRIPTION
Implements [#6](https://github.com/Prior99/jest-screenshot/issues/6)

Also added ```.idea``` folder (generated by JetBrains WebStorm) to ```.gitignore```.
Unfortunatelly, many tests are failing on windows due to slashes mismatch. 
I've checked manually and the only non-slash failing test is "uses `0` as relative threshold if no threshold is provided":
```Expected mock function to have been called with: {"pixelThresholdRelative": 0} as argument 2, but it was called with {"colorThreshold": 0, "pixelThresholdRelative": 0}.```
But it seems unrelated to changes made in this PR.